### PR TITLE
Fix s3 URL

### DIFF
--- a/bin/utils/distribute.js
+++ b/bin/utils/distribute.js
@@ -1,4 +1,4 @@
-// This will invalidate CloudFront based on S3
+// This will do many stuffs based on S3 bucket name
 // The app need to know the AWS_S3_BUCKET
 
 const { exec, execSync } = require('child_process');
@@ -55,7 +55,8 @@ const isInvalid = distribution => {
 
 const getDistributions = s3URL => new Promise((resolve, reject) => {
   const matchedS3Bucket = distribution => {
-    return getOrigin(distribution).DomainName === s3URL;
+    const DomainName = getOrigin(distribution).DomainName;
+    return (DomainName.indexOf(AWS_S3_BUCKET) > -1);
   };
 
   const isEnabled = distribution => (distribution.Enabled === true);
@@ -69,7 +70,7 @@ const getDistributions = s3URL => new Promise((resolve, reject) => {
     const distributions = JSON
       .parse(stdout).DistributionList.Items
       .filter(isEnabled)
-      .filter(matchedS3Bucket)
+      .filter(matchedS3Bucket);
 
     resolve({ s3URL, distributions });
   });

--- a/bin/utils/distribute.js
+++ b/bin/utils/distribute.js
@@ -16,6 +16,23 @@ const AWS_S3_BUCKET = process.env.AWS_S3_BUCKET;
 const BUILD_DIR = process.env.BUILD_DIR;
 const AWS_CLI = `${BUILD_DIR}/bin/aws`;
 
+const s3Hosting = {
+  'us-east-2': 's3-website.us-east-2.amazonaws.com',
+  'us-east-1': 's3-website-us-east-1.amazonaws.com',
+  'us-west-1': 's3-website-us-west-1.amazonaws.com',
+  'us-west-2': 's3-website-us-west-2.amazonaws.com',
+  'ca-central-1': 's3-website.ca-central-1.amazonaws.com',
+  'ap-south-1': 's3-website.ap-south-1.amazonaws.com',
+  'ap-northeast-2': 's3-website.ap-northeast-2.amazonaws.com',
+  'ap-southeast-1': 's3-website-ap-southeast-1.amazonaws.com',
+  'ap-southeast-2': 's3-website-ap-southeast-2.amazonaws.com',
+  'ap-northeast-1': 's3-website-ap-northeast-1.amazonaws.com',
+  'eu-central-1': 's3-website.eu-central-1.amazonaws.com',
+  'eu-west-1': 's3-website-eu-west-1.amazonaws.com',
+  'eu-west-2': 's3-website.eu-west-2.amazonaws.com',
+  'sa-east-1': 's3-website-sa-east-1.amazonaws.com',
+};
+
 const getS3URL = bucket => new Promise((resolve, reject) => {
   exec(`${AWS_CLI} s3api get-bucket-location --bucket ${bucket}`, (error, stdout, stderr) => {
     if (error) {
@@ -25,7 +42,7 @@ const getS3URL = bucket => new Promise((resolve, reject) => {
 
     const response = JSON.parse(stdout);
     const region = response.LocationConstraint;
-    const url = `${bucket}.s3-website-${region}.amazonaws.com`;
+    const url = s3Hosting[region];
     resolve(url);
   });
 });
@@ -55,8 +72,7 @@ const isInvalid = distribution => {
 
 const getDistributions = s3URL => new Promise((resolve, reject) => {
   const matchedS3Bucket = distribution => {
-    const DomainName = getOrigin(distribution).DomainName;
-    return (DomainName.indexOf(AWS_S3_BUCKET) > -1);
+    return getOrigin(distribution).DomainName === s3URL;
   };
 
   const isEnabled = distribution => (distribution.Enabled === true);


### PR DESCRIPTION
Origin | CNAME
-- | -- |
qryptos-stag4.s3-website-us-east-2.amazonaws.com/home | qryptos-stag4-home.quoine.io |  
qryptos-stag4.s3-website-us-east-2.amazonaws.com/tokens | qryptos-stag4-tokens.quoine.io |  
qryptos-stag4.s3-website.us-east-2.amazonaws.com/accounts | qryptos-stag4-accounts.quoine.io |  
qryptos-stag4.s3-website.us-east-2.amazonaws.com/chart | qryptos-stag4-chart.quoine.io |  
qryptos-stag4.s3-website.us-east-2.amazonaws.com/trade | qryptos-stag4-trade.quoine.io

As above, both `s3-website-` (dash) or `s3-website.` (dot) is valid for s3 website, I don't know why but we need to change how we filter CloudFront based on s3. Previous I use the full URL.

===================

Now I found why here: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
